### PR TITLE
train() only returns valid_err

### DIFF
--- a/session2/train_nmt.py
+++ b/session2/train_nmt.py
@@ -4,7 +4,7 @@ from nmt import train
 
 def main(job_id, params):
     print params
-    trainerr, validerr, testerr = train(saveto=params['model'][0],
+    validerr = train(saveto=params['model'][0],
                                         reload_=params['reload'][0],
                                         dim_word=params['dim_word'][0],
                                         dim=params['dim'][0],


### PR DESCRIPTION
Hi,

train() method at present only returns valid_err. The helper file train_nmt.py should be fixed to reflect that.
