### PR TITLE
Fixed default arguments

### DIFF
--- a/data/download_files.py
+++ b/data/download_files.py
@@ -16,12 +16,12 @@ indicators. Adapted from,
 https://github.com/orhanf/blocks-examples/tree/master/machine_translation
 """, formatter_class=argparse.RawTextHelpFormatter)
 parser.add_argument("-s", "--source", type=str, help="Source language",
-                    default="cs")
+                    default="fr")
 parser.add_argument("-t", "--target", type=str, help="Target language",
                     default="en")
-parser.add_argument("--source-dev", type=str, default="newstest2013.cs",
+parser.add_argument("--source-dev", type=str, default="newstest2011.fr",
                     help="Source language dev filename")
-parser.add_argument("--target-dev", type=str, default="newstest2013.en",
+parser.add_argument("--target-dev", type=str, default="newstest2011.en",
                     help="Target language dev filename")
 parser.add_argument("--outdir", type=str, default=".",
                     help="Output directory")


### PR DESCRIPTION
Fixed default arguments so that they are compatible with `TRAIN_DATA_URL` and `VALID_DATA_URL`.

Otherwise, we get the following error (since we're looking for files that don't exist in the archives `fr-en.tgz` and `newstest2011.tgz`):

```
francky@server:~/dl4mt-material-master/data$ python download_files.py
INFO:prepare_data:Downloading [http://www.statmt.org/europarl/v7/fr-en.tgz]
INFO:prepare_data:...saving to: ./train_data.tgz 
INFO:prepare_data:Extracting file [./train_data.tgz] into [.]
ERROR:prepare_data:[[]] pair does not exist in the archive!

INFO:prepare_data:Downloading [http://matrix.statmt.org/test_sets/newstest2011.tgz]
INFO:prepare_data:...saving to: ./valid_data.tgz
INFO:prepare_data:Extracting file [./valid_data.tgz] into [.]
ERROR:prepare_data:[[]] pair does not exist in the archive!                   
```
