### PR TITLE
nmt: typo in variable names

### DIFF
--- a/session1/nmt.py
+++ b/session1/nmt.py
@@ -911,7 +911,7 @@ def train(dim_word=100,  # word vector dimensionality
     if reload_ and os.path.exists(saveto):
         print 'Reloading model options'
         with open('%s.pkl' % saveto, 'rb') as f:
-            models_options = pkl.load(f)
+            model_options = pkl.load(f)
 
     print 'Loading data'
     train = TextIterator(datasets[0], datasets[1],

--- a/session2/nmt.py
+++ b/session2/nmt.py
@@ -1037,7 +1037,7 @@ def train(dim_word=100,  # word vector dimensionality
     if reload_ and os.path.exists(saveto):
         print 'Reloading model options'
         with open('%s.pkl' % saveto, 'rb') as f:
-            models_options = pkl.load(f)
+            model_options = pkl.load(f)
 
     print 'Loading data'
     train = TextIterator(datasets[0], datasets[1],

--- a/session3/nmt.py
+++ b/session3/nmt.py
@@ -1037,7 +1037,7 @@ def train(dim_word=100,  # word vector dimensionality
     if reload_ and os.path.exists(saveto):
         print 'Reloading model options'
         with open('%s.pkl' % saveto, 'rb') as f:
-            models_options = pkl.load(f)
+            model_options = pkl.load(f)
 
     print 'Loading data'
     train = TextIterator(datasets[0], datasets[1],


### PR DESCRIPTION
The model options were actually reloaded into a never used dict.
